### PR TITLE
Fix improper handling of tied scores

### DIFF
--- a/underdogpickem/football256.py
+++ b/underdogpickem/football256.py
@@ -36,22 +36,21 @@ for tr in trs:
         continue
     scores.append((tds[0].text.strip(), tds[1].text.strip(), tds[2].text.strip()))
 
-scores_clean = {}
-sentinel = -1
+scores_clean = []
+rank = 0
 for score in scores:
-    t = []
-    if score[0] == '':
-        t.append(sentinel)
-        sentinel = sentinel - 1
-    else:
-        t.append(int(score[0]))
-    t.append(score[1])
-    t.append(int(score[2]))
-    scores_clean[t[0]] = [score[1], int(score[2])]
+    if score[0]:
+        # if there's a value in the first column, that's the rank.
+        # Otherwise, reuse the last one we've seen
+        rank = int(score[0])
+
+    scores_clean.append([rank, score[1], int(score[2])])
 
 out = []
-for (k) in sorted(scores_clean.keys())[::-1]:
-    out.append(scores_clean[k][0] + " : " + str(scores_clean[k][1]))
+# this will use alphabetical order as the tiebreak, which is good enough
+for rank, user_name, score in sorted(scores_clean):
+    out.append('({rank}) {user_name}: {score}'.format(
+        rank=rank, user_name=user_name, score=score))
 
 payload_json = {"text": "\n*Current Pick'em Standings*\n" + "\n".join(out)}
 


### PR DESCRIPTION
1. Stop using incorrectly-updated sentinel value. Instead, just use the previously-seen rank for both users.
2. Switch the cleaned up scores from a dict (which requires unique keys, and keys can't be unique if there are ties) to a list of 3-tuples: rank, user name, score
3. Update the output format to drop the space between the user name and colon

New output:
```python
{'text': "\n*Current Pick'em Standings*\n(1) joescii: 33\n(2) mjcarroll: 27\n(3) david.jones: 14\n(4) chris.wallace: 13\n(5) drewmcdowell: 12\n(5) red.foxx15: 12\n(7) adamepling: 4\n(8) drewbrew: 0"}
```